### PR TITLE
Added support for French (AZERTY)

### DIFF
--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -3,5 +3,6 @@
   "KEYBOARDLAYOUT.SettingsKeyboardLayoutHint": "Wähle die Tastaturbelegung aus, die für Shortcuts verwendet werden soll.",
   "KEYBOARDLAYOUT.KeyboardLayoutUS": "US (QWERTY)",
   "KEYBOARDLAYOUT.KeyboardLayoutDeLatin1": "Deutsch (QWERTZ)",
-  "KEYBOARDLAYOUT.KeyboardLayoutSvLatin1": "Schwedisch (QWERTY)"
+  "KEYBOARDLAYOUT.KeyboardLayoutSvLatin1": "Schwedisch (QWERTY)",
+  "KEYBOARDLAYOUT.KeyboardLayoutFr": "Französisch (AZERTY)"
 }

--- a/src/lang/de.json.license
+++ b/src/lang/de.json.license
@@ -1,4 +1,5 @@
 SPDX-FileCopyrightText: 2021 Johannes Loher
 SPDX-FileCopyrightText: 2021 Martin (fohswe#8355), GH: plutoneld
 SPDX-FileCopyrightText: 2021 Max VS (Maximus#6001)
+
 SPDX-License-Identifier: MIT

--- a/src/lang/de.json.license
+++ b/src/lang/de.json.license
@@ -1,4 +1,4 @@
 SPDX-FileCopyrightText: 2021 Johannes Loher
 SPDX-FileCopyrightText: 2021 Martin (fohswe#8355), GH: plutoneld
-
+SPDX-FileCopyrightText: 2021 Max VS (Maximus#6001)
 SPDX-License-Identifier: MIT

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -3,5 +3,6 @@
   "KEYBOARDLAYOUT.SettingsKeyboardLayoutHint": "Choose the keyboard layout to use for keybindings.",
   "KEYBOARDLAYOUT.KeyboardLayoutUS": "US (QWERTY)",
   "KEYBOARDLAYOUT.KeyboardLayoutDeLatin1": "German (QWERTZ)",
-  "KEYBOARDLAYOUT.KeyboardLayoutSvLatin1": "Swedish (QWERTY)"
+  "KEYBOARDLAYOUT.KeyboardLayoutSvLatin1": "Swedish (QWERTY)",
+  "KEYBOARDLAYOUT.KeyboardLayoutFr": "French (AZERTY)"
 }

--- a/src/lang/en.json.license
+++ b/src/lang/en.json.license
@@ -1,4 +1,5 @@
 SPDX-FileCopyrightText: 2021 Johannes Loher
 SPDX-FileCopyrightText: 2021 Martin (fohswe#8355), GH: plutoneld
 SPDX-FileCopyrightText: 2021 Max VS (Maximus#6001)
+
 SPDX-License-Identifier: MIT

--- a/src/lang/en.json.license
+++ b/src/lang/en.json.license
@@ -1,4 +1,4 @@
 SPDX-FileCopyrightText: 2021 Johannes Loher
 SPDX-FileCopyrightText: 2021 Martin (fohswe#8355), GH: plutoneld
-
+SPDX-FileCopyrightText: 2021 Max VS (Maximus#6001)
 SPDX-License-Identifier: MIT

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -1,0 +1,8 @@
+{
+  "KEYBOARDLAYOUT.SettingsKeyboardLayoutName": "Disposition du clavier",
+  "KEYBOARDLAYOUT.SettingsKeyboardLayoutHint": "Choisissez la disposition du clavier à utiliser pour les combinaisons de touches",
+  "KEYBOARDLAYOUT.KeyboardLayoutUS": "US (QWERTY)",
+  "KEYBOARDLAYOUT.KeyboardLayoutDeLatin1": "Allemand (QWERTZ)",
+  "KEYBOARDLAYOUT.KeyboardLayoutSvLatin1": "Suédois (QWERTY)",
+  "KEYBOARDLAYOUT.KeyboardLayoutFr": "Français (AZERTY)"
+}

--- a/src/lang/fr.json.license
+++ b/src/lang/fr.json.license
@@ -1,3 +1,2 @@
-SPDX-FileCopyrightText: 2021 Martin (fohswe#8355), GH: plutoneld
 SPDX-FileCopyrightText: 2021 Max VS (Maximus#6001)
 SPDX-License-Identifier: MIT

--- a/src/lang/fr.json.license
+++ b/src/lang/fr.json.license
@@ -1,2 +1,3 @@
 SPDX-FileCopyrightText: 2021 Max VS (Maximus#6001)
+
 SPDX-License-Identifier: MIT

--- a/src/lang/sv.json
+++ b/src/lang/sv.json
@@ -3,5 +3,6 @@
   "KEYBOARDLAYOUT.SettingsKeyboardLayoutHint": "Välj vilken tangentbordslayout som ska gälla för tangentbordsgenvägar.",
   "KEYBOARDLAYOUT.KeyboardLayoutUS": "US (QWERTY)",
   "KEYBOARDLAYOUT.KeyboardLayoutDeLatin1": "Tyska (QWERTZ)",
-  "KEYBOARDLAYOUT.KeyboardLayoutSvLatin1": "Svenska (QWERTY)"
+  "KEYBOARDLAYOUT.KeyboardLayoutSvLatin1": "Svenska (QWERTY)",
+  "KEYBOARDLAYOUT.KeyboardLayoutFr": "Franska (AZERTY)"
 }

--- a/src/lang/sv.json.license
+++ b/src/lang/sv.json.license
@@ -1,3 +1,4 @@
 SPDX-FileCopyrightText: 2021 Martin (fohswe#8355), GH: plutoneld
 SPDX-FileCopyrightText: 2021 Max VS (Maximus#6001)
+
 SPDX-License-Identifier: MIT

--- a/src/module.json
+++ b/src/module.json
@@ -30,6 +30,11 @@
       "lang": "sv",
       "name": "Svenska",
       "path": "lang/sv.json"
+    },
+    {
+      "lang": "fr",
+      "name": "Français",
+      "path": "lang/fr.json"
     }
   ],
   "socket": true,

--- a/src/module.json.license
+++ b/src/module.json.license
@@ -1,4 +1,5 @@
 SPDX-FileCopyrightText: 2021 Johannes Loher
 SPDX-FileCopyrightText: 2021 Martin (fohswe#8355), GH: plutoneld
+SPDX-FileCopyrightText: 2021 Max VS (Maximus#6001)
 
 SPDX-License-Identifier: MIT

--- a/src/module/keyboard-layouts/fr.js
+++ b/src/module/keyboard-layouts/fr.js
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2021 Max VS (Maximus#6001)
+//
 // SPDX-License-Identifier: MIT
 
 export const fr = {

--- a/src/module/keyboard-layouts/fr.js
+++ b/src/module/keyboard-layouts/fr.js
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2021 Max VS (Maximus#6001)
+// SPDX-FileCopyrightText: 2021 Max VS (Maximus#6001)
 // SPDX-License-Identifier: MIT
 
 export const fr = {

--- a/src/module/keyboard-layouts/fr.js
+++ b/src/module/keyboard-layouts/fr.js
@@ -1,0 +1,41 @@
+//SPDX-FileCopyrightText: 2021 Max VS (Maximus#6001)
+// SPDX-License-Identifier: MIT
+
+export const fr = {
+  keycodeDisplayMapping: {
+    KeyW: 'Z',
+    KeyZ: 'W',
+    KeyQ: 'A',
+    KeyA: 'Q',
+    KeyM: ',',
+    Minus: ')',
+    Equal: '=',
+    BracketRight: '$',
+    BracketLeft: '^',
+    Digit0: 'à',
+    Digit1: '&',
+    Digit2: 'é',
+    Digit3: '"',
+    Digit4: "'",
+    Digit5: '(',
+    Digit6: '-',
+    Digit7: 'è',
+    Digit8: '_',
+    Digit9: 'ç',
+    Semicolon: 'M',
+    Period: ':',
+    Backquote: '²',
+    Quote: 'ù',
+    IntlBackslash: '<',
+    Backslash: '*',
+    Slash: '!',
+    Comma: ';',
+  },
+
+  keybindingMapping: {
+    KeyZ: 'KeyW',
+    Minus: 'Digit6',
+  },
+
+  i18n: 'KEYBOARDLAYOUT.KeyboardLayoutFr',
+};

--- a/src/module/keyboard-layouts/index.js
+++ b/src/module/keyboard-layouts/index.js
@@ -6,9 +6,11 @@
 import { us } from './us.js';
 import { deLatin1 } from './de-latin1.js';
 import { svLatin1 } from './sv-latin1.js';
+import { fr } from './fr.js';
 
 export const keyboardLayouts = {
   us,
   deLatin1,
   svLatin1,
+  fr,
 };

--- a/src/module/keyboard-layouts/index.js
+++ b/src/module/keyboard-layouts/index.js
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2021 Johannes Loher
 // SPDX-FileCopyrightText: 2021 Martin (fohswe#8355), GH: plutoneld
+// SPDX-FileCopyrightText: 2021 Max VS (Maximus#6001)
 //
 // SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
Hey,

I added support for AZERTY using a French keyboard layout. I ended up only remapping Z to support CTRL+Z to undo. I tested remapping Q so you could CTRL+A to select all, but that ended up breaking movement using the Azerty equivalent of WASD so I left it as it is, users can always simply add CTRL+A manually as the keys are displayed correctly now.