### PR TITLE
feat: add hungarian layout

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -6,5 +6,6 @@
   "KEYBOARDLAYOUT.KeyboardLayoutSvLatin1": "Schwedisch (QWERTY)",
   "KEYBOARDLAYOUT.KeyboardLayoutFr": "Französisch (AZERTY)",
   "KEYBOARDLAYOUT.KeyboardLayoutColemak": "Colemak",
-  "KEYBOARDLAYOUT.KeyboardLayoutDvorak": "Dvorak"
+  "KEYBOARDLAYOUT.KeyboardLayoutDvorak": "Dvorak",
+  "KEYBOARDLAYOUT.KeyboardLayoutHu": "Ungarisch (QWERTZ)"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -6,5 +6,6 @@
   "KEYBOARDLAYOUT.KeyboardLayoutSvLatin1": "Swedish (QWERTY)",
   "KEYBOARDLAYOUT.KeyboardLayoutFr": "French (AZERTY)",
   "KEYBOARDLAYOUT.KeyboardLayoutColemak": "Colemak",
-  "KEYBOARDLAYOUT.KeyboardLayoutDvorak": "Dvorak"
+  "KEYBOARDLAYOUT.KeyboardLayoutDvorak": "Dvorak",
+  "KEYBOARDLAYOUT.KeyboardLayoutHu": "Hungarian (QWERTZ)"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -6,5 +6,6 @@
   "KEYBOARDLAYOUT.KeyboardLayoutSvLatin1": "Suédois (QWERTY)",
   "KEYBOARDLAYOUT.KeyboardLayoutFr": "Français (AZERTY)",
   "KEYBOARDLAYOUT.KeyboardLayoutColemak": "Colemak",
-  "KEYBOARDLAYOUT.KeyboardLayoutDvorak": "Dvorak"
+  "KEYBOARDLAYOUT.KeyboardLayoutDvorak": "Dvorak",
+  "KEYBOARDLAYOUT.KeyboardLayoutHu": "Hongroise (QWERTZ)"
 }

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -6,5 +6,6 @@
   "KEYBOARDLAYOUT.KeyboardLayoutSvLatin1": "Svenska (QWERTY)",
   "KEYBOARDLAYOUT.KeyboardLayoutFr": "Franska (AZERTY)",
   "KEYBOARDLAYOUT.KeyboardLayoutColemak": "Colemak",
-  "KEYBOARDLAYOUT.KeyboardLayoutDvorak": "Dvorak"
+  "KEYBOARDLAYOUT.KeyboardLayoutDvorak": "Dvorak",
+  "KEYBOARDLAYOUT.KeyboardLayoutHu": "Ungerska (QWERTZ)"
 }

--- a/src/keyboard-layouts/hu.js
+++ b/src/keyboard-layouts/hu.js
@@ -1,0 +1,26 @@
+export const hu = {
+  keycodeDisplayMapping: {
+    Backquote: '0',
+    Digit0: 'Ö',
+    Minus: 'Ü',
+    Equal: 'Ó',
+    KeyY: 'Z',
+    BracketLeft: 'Ő',
+    BracketRight: 'Ú',
+    Semicolon: 'É',
+    Quote: 'Á',
+    Backslash: 'Ű',
+    IntlBackslash: 'Í',
+    KeyZ: 'Y',
+    Slash: '-',
+  },
+
+  keybindingMapping: {
+    KeyY: 'KeyZ',
+    KeyZ: 'KeyY',
+    Digit0: 'Backquote',
+    Minus: 'Slash',
+  },
+
+  i18n: 'KEYBOARDLAYOUT.KeyboardLayoutHu',
+};

--- a/src/keyboard-layouts/index.js
+++ b/src/keyboard-layouts/index.js
@@ -10,6 +10,7 @@ import { dvorak } from './dvorak.js';
 import { fr } from './fr.js';
 import { svLatin1 } from './sv-latin1.js';
 import { us } from './us.js';
+import { hu } from './hu.js';
 
 export const keyboardLayouts = {
   colemak,
@@ -18,4 +19,5 @@ export const keyboardLayouts = {
   fr,
   svLatin1,
   us,
+  hu,
 };


### PR DESCRIPTION
- Added hungarian keyboard layout.
- Extended lang files (de, en, sweden, fr) to include the hungarian layout's name.

Should I add `hu.json` and `hu.json.license` files too?
